### PR TITLE
Limited concurrency for whois requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": ">=9.3"
   },
   "dependencies": {
+    "async": "^2.6.0",
     "parse-domain": "^2.0.0",
     "puppeteer": "^1.1.0",
     "url-parse": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,12 @@ async-limiter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
 
+async@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
+  dependencies:
+    lodash "^4.14.0"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -209,6 +215,10 @@ locate-path@^2.0.0:
   dependencies:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
+
+lodash@^4.14.0:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
 lru-cache@^4.0.1:
   version "4.1.1"


### PR DESCRIPTION
- Concurrency limited to 30 concurrent whois requests
- Improved whois data caching and fetching
- More resilient data logging
- Allow child process to live for a maximum of 5 seconds